### PR TITLE
[1/n - 6] home("/") 경로 외에도 검색창이 보이는 오류 해결 

### DIFF
--- a/src/component/Header/Header.jsx
+++ b/src/component/Header/Header.jsx
@@ -26,8 +26,6 @@ const Header = () => {
     );
   };
 
-  const [pathname, setPathname] = useState(window.location.pathname);
-
   const onSearch = (keyword) => {
     // keyword 서버로 넘겨주기
   };
@@ -39,7 +37,7 @@ const Header = () => {
           <img src="#" alt="logo" />
         </ImgWrapper>
 
-        {pathname === "/" ? (
+        {window.location.pathname === "/" ? (
           <SearchBarWrapper>
             <SearchBar onSearchListener={onSearch} />
 


### PR DESCRIPTION
### ✨ 작업한 내용
- `pathname` 이라는 state 대신, `window.location.pathname`를 사용
---
### ❗ 리뷰 시 참고사항
url 변경이 즉각적으로 반영되도록 하기 위해, state가 아닌 url의 pathname을 직접 가져오는 방식으로 변경하였습니다.

---

### 💡 새롭게 알게 된 점

---

### ❓ 고민 중인 부분

---

### 📘 참고 자료 
