### PR TITLE
[1/n - 9] home("/") 경로 이외에서 헤더가 다른 컴포넌트랑 겹치는 문제 해결

### DIFF
--- a/src/component/Header/Header.jsx
+++ b/src/component/Header/Header.jsx
@@ -32,7 +32,7 @@ const Header = () => {
 
   return (
     <div>
-      <HeaderWrapper>
+      <HeaderWrapper isHome={window.location.pathname === "/"}>
         <ImgWrapper onClick={onLogoClick}>
           <img src="#" alt="logo" />
         </ImgWrapper>
@@ -75,7 +75,7 @@ const HeaderWrapper = styled.div`
   flex-direction: row;
   align-items: stretch;
   justify-content: space-between;
-  position: fixed;
+  position: ${({ isHome }) => (isHome ? "fixed" : "static")};
   top: 0;
   width: 100vw;
   background-color: #ffc15c;


### PR DESCRIPTION
### ✨ 작업한 내용
- `window.location.pathname`에 따라 `header` 컴포넌트의 `position` 변경 
---
### ❗ 리뷰 시 참고사항
`HeaderWrapper` 스타일 컴포넌트에 `isHome`이라는 변수를 추가하여 , 현재 경로가 "/"이면 `position : fixed` 속성을, 아닌 경우에는 `position : static` 속성을 가지도록 구현하였습니다. 

---

### 💡 새롭게 알게 된 점

---

### ❓ 고민 중인 부분

---

### 📘 참고 자료 

---

Fixes #31 
