### PR TITLE
[1/n - 3] 아이디/비밀번호 찾기 페이지 구현

### DIFF
--- a/src/component/find/findIdForm.jsx
+++ b/src/component/find/findIdForm.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+const FindIdForm = ({ name, tel, onNameChange, onTelChange, findId }) => {
+  return (
+    <>
+      <div>
+        <input
+          type="text"
+          value={name}
+          onChange={onNameChange}
+          placeholder="이름"
+        />
+        <input
+          type="tel"
+          value={tel}
+          onChange={onTelChange}
+          placeholder="전화번호"
+        />
+      </div>
+      <button onClick={findId}>아이디 찾기</button>
+    </>
+  );
+};
+
+export default FindIdForm;

--- a/src/component/find/findIdForm.jsx
+++ b/src/component/find/findIdForm.jsx
@@ -1,23 +1,28 @@
 import React from "react";
+import {
+  InputContainer,
+  InputWrapper,
+  FindButton,
+} from "../style/findFormStyle";
 
 const FindIdForm = ({ name, tel, onNameChange, onTelChange, findId }) => {
   return (
     <>
-      <div>
-        <input
+      <InputContainer>
+        <InputWrapper
           type="text"
           value={name}
           onChange={onNameChange}
           placeholder="이름"
         />
-        <input
+        <InputWrapper
           type="tel"
           value={tel}
           onChange={onTelChange}
           placeholder="전화번호"
         />
-      </div>
-      <button onClick={findId}>아이디 찾기</button>
+      </InputContainer>
+      <FindButton onClick={findId}>아이디 찾기</FindButton>
     </>
   );
 };

--- a/src/component/find/findPwForm.jsx
+++ b/src/component/find/findPwForm.jsx
@@ -1,4 +1,9 @@
 import React from "react";
+import {
+  InputContainer,
+  InputWrapper,
+  FindButton,
+} from "../style/findFormStyle";
 
 const FindPwForm = ({
   id,
@@ -11,27 +16,27 @@ const FindPwForm = ({
 }) => {
   return (
     <>
-      <div>
-        <input
+      <InputContainer>
+        <InputWrapper
           type="text"
           value={id}
           onChange={onIdChange}
           placeholder="아이디"
         />
-        <input
+        <InputWrapper
           type="text"
           value={name}
           onChange={onNameChange}
           placeholder="이름"
         />
-        <input
+        <InputWrapper
           type="tel"
           value={tel}
           onChange={onTelChange}
           placeholder="전화번호"
         />
-      </div>
-      <button onClick={findPw}>비밀번호 찾기</button>
+      </InputContainer>
+      <FindButton onClick={findPw}>비밀번호 찾기</FindButton>
     </>
   );
 };

--- a/src/component/find/findPwForm.jsx
+++ b/src/component/find/findPwForm.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+const FindPwForm = ({
+  id,
+  name,
+  tel,
+  onIdChange,
+  onNameChange,
+  onTelChange,
+  findPw,
+}) => {
+  return (
+    <>
+      <div>
+        <input
+          type="text"
+          value={id}
+          onChange={onIdChange}
+          placeholder="아이디"
+        />
+        <input
+          type="text"
+          value={name}
+          onChange={onNameChange}
+          placeholder="이름"
+        />
+        <input
+          type="tel"
+          value={tel}
+          onChange={onTelChange}
+          placeholder="전화번호"
+        />
+      </div>
+      <button onClick={findPw}>비밀번호 찾기</button>
+    </>
+  );
+};
+
+export default FindPwForm;

--- a/src/component/login/loginForm.jsx
+++ b/src/component/login/loginForm.jsx
@@ -8,8 +8,11 @@ import { useNavigate } from "react-router-dom";
 const LoginForm = (props) => {
   const navigate = useNavigate();
   const [data, setData] = useState({ id: "" }, { pw: "" });
-  const onFindClick = () => {
-    navigate("/find");
+  const onFindIdClick = () => {
+    navigate("/find/id");
+  };
+  const onFindPwClick = () => {
+    navigate("/find/pw");
   };
   const onLogin = () => {
     navigate("/");
@@ -24,8 +27,8 @@ const LoginForm = (props) => {
         <KakaoButton />
       </FormContainer>
       <SpanContainer>
-        <span onClick={onFindClick}>아이디 찾기</span>
-        <span onClick={onFindClick}>비밀번호 찾기</span>
+        <span onClick={onFindIdClick}>아이디 찾기</span>
+        <span onClick={onFindPwClick}>비밀번호 찾기</span>
       </SpanContainer>
     </>
   );

--- a/src/component/style/findFormStyle.jsx
+++ b/src/component/style/findFormStyle.jsx
@@ -1,0 +1,22 @@
+import styled from "styled-components";
+
+export const InputWrapper = styled.input`
+  border-color: rgba(1, 1, 1, 0.2);
+  margin: 1rem;
+`;
+
+export const InputContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const FindButton = styled.button`
+  margin-top: 2rem;
+  width: 11.5rem;
+  height: 2.5rem;
+  border: none;
+  border-radius: 7px;
+  background-color: #b2acfa;
+  color: white;
+`;

--- a/src/component/style/findPageStyle.jsx
+++ b/src/component/style/findPageStyle.jsx
@@ -1,0 +1,17 @@
+import styled from "styled-components";
+
+export const PageWrapper = styled.div`
+  margin-top: 5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export const FindPageHeader = styled.div`
+  width: 60vw;
+  display: flex;
+  justify-content: space-evenly;
+  margin-top: 1rem;
+  margin-bottom: 4rem;
+`;

--- a/src/pages/findIdPage.jsx
+++ b/src/pages/findIdPage.jsx
@@ -1,5 +1,9 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
+import { PageWrapper, FindPageHeader } from "../component/style/findPageStyle";
+import { useState } from "react";
+import FindIdForm from "../component/find/findIdForm";
+
 const FindIdPage = () => {
   const navigate = useNavigate();
   const [id, setId] = useState("");
@@ -25,12 +29,12 @@ const FindIdPage = () => {
     // TODO: 서버와 통신
   };
   return (
-    <>
+    <PageWrapper>
       <h1>아이디 / 비밀번호 찾기</h1>
-      <div>
+      <FindPageHeader>
         <span onClick={onIdClick}>아이디 찾기</span>
         <span onClick={onPwClick}>비밀번호 찾기</span>
-      </div>
+      </FindPageHeader>
       <FindIdForm
         name={name}
         tel={tel}
@@ -38,7 +42,7 @@ const FindIdPage = () => {
         onTelChange={onTelChange}
         findId={findId}
       />
-    </>
+    </PageWrapper>
   );
 };
 

--- a/src/pages/findIdPage.jsx
+++ b/src/pages/findIdPage.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+const FindIdPage = () => {
+  const navigate = useNavigate();
+  const [id, setId] = useState("");
+  const [name, setName] = useState("");
+  const [tel, setTel] = useState("");
+  const onNameChange = (e) => {
+    const val = e.target.value;
+    //
+    setName(val);
+  };
+  const onTelChange = (e) => {
+    const val = e.target.value;
+    //
+    setTel(val);
+  };
+  const onIdClick = () => {
+    navigate("/find-id");
+  };
+  const onPwClick = () => {
+    navigate("/find-pw");
+  };
+  const findId = () => {
+    // TODO: 서버와 통신
+  };
+  return (
+    <>
+      <h1>아이디 / 비밀번호 찾기</h1>
+      <div>
+        <span onClick={onIdClick}>아이디 찾기</span>
+        <span onClick={onPwClick}>비밀번호 찾기</span>
+      </div>
+      <FindIdForm
+        name={name}
+        tel={tel}
+        onNameChange={onNameChange}
+        onTelChange={onTelChange}
+        findId={findId}
+      />
+    </>
+  );
+};
+
+export default FindIdPage;

--- a/src/pages/findIdPage.jsx
+++ b/src/pages/findIdPage.jsx
@@ -20,10 +20,10 @@ const FindIdPage = () => {
     setTel(val);
   };
   const onIdClick = () => {
-    navigate("/find-id");
+    navigate("/find/id");
   };
   const onPwClick = () => {
-    navigate("/find-pw");
+    navigate("/find/pw");
   };
   const findId = () => {
     // TODO: 서버와 통신

--- a/src/pages/findPwPage.jsx
+++ b/src/pages/findPwPage.jsx
@@ -25,10 +25,10 @@ const FindPwPage = (props) => {
     setTel(val);
   };
   const onIdClick = () => {
-    navigate("/find-id");
+    navigate("/find/id");
   };
   const onPwClick = () => {
-    navigate("/find-pw");
+    navigate("/find/pw");
   };
   const findPw = () => {
     // TODO: 서버와 통신

--- a/src/pages/findPwPage.jsx
+++ b/src/pages/findPwPage.jsx
@@ -1,6 +1,8 @@
 import React from "react";
-import FindPwForm from "../component/find/findPwForm";
 import { useNavigate } from "react-router-dom";
+import { PageWrapper, FindPageHeader } from "../component/style/findPageStyle";
+import { useState } from "react";
+import FindPwForm from "../component/find/findPwForm";
 
 const FindPwPage = (props) => {
   const navigate = useNavigate();
@@ -32,12 +34,12 @@ const FindPwPage = (props) => {
     // TODO: 서버와 통신
   };
   return (
-    <>
+    <PageWrapper>
       <h1>아이디 / 비밀번호 찾기</h1>
-      <div>
+      <FindPageHeader>
         <span onClick={onIdClick}>아이디 찾기</span>
         <span onClick={onPwClick}>비밀번호 찾기</span>
-      </div>
+      </FindPageHeader>
       <FindPwForm
         id={id}
         name={name}
@@ -47,7 +49,7 @@ const FindPwPage = (props) => {
         onTelChange={onTelChange}
         findPw={findPw}
       />
-    </>
+    </PageWrapper>
   );
 };
 

--- a/src/pages/findPwPage.jsx
+++ b/src/pages/findPwPage.jsx
@@ -1,0 +1,54 @@
+import React from "react";
+import FindPwForm from "../component/find/findPwForm";
+import { useNavigate } from "react-router-dom";
+
+const FindPwPage = (props) => {
+  const navigate = useNavigate();
+  const [id, setId] = useState("");
+  const [name, setName] = useState("");
+  const [tel, setTel] = useState("");
+  const onIdChange = (e) => {
+    const val = e.target.value;
+    //
+    setId(val);
+  };
+  const onNameChange = (e) => {
+    const val = e.target.value;
+    //
+    setName(val);
+  };
+  const onTelChange = (e) => {
+    const val = e.target.value;
+    //
+    setTel(val);
+  };
+  const onIdClick = () => {
+    navigate("/find-id");
+  };
+  const onPwClick = () => {
+    navigate("/find-pw");
+  };
+  const findPw = () => {
+    // TODO: 서버와 통신
+  };
+  return (
+    <>
+      <h1>아이디 / 비밀번호 찾기</h1>
+      <div>
+        <span onClick={onIdClick}>아이디 찾기</span>
+        <span onClick={onPwClick}>비밀번호 찾기</span>
+      </div>
+      <FindPwForm
+        id={id}
+        name={name}
+        tel={tel}
+        onIdChange={onIdChange}
+        onNameChange={onNameChange}
+        onTelChange={onTelChange}
+        findPw={findPw}
+      />
+    </>
+  );
+};
+
+export default FindPwPage;

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -5,6 +5,8 @@ import ChatPage from "../pages/chat/ChatPage";
 import SignUpPage from "../pages/SignUpPage";
 import Home from "../pages/home";
 import LoginPage from "../pages/loginPage";
+import FindIdPage from "../pages/findIdPage";
+import FindPwPage from "../pages/findPwPage";
 const Router = () => {
   return (
     <div>
@@ -15,6 +17,8 @@ const Router = () => {
         <Route path="/signup" element={<SignUpPage />} />
         <Route path="/chat" element={<ChatPage />} />
         <Route path="/login" element={<LoginPage />} />
+        <Route path="/find/id" element={<FindIdPage />} />
+        <Route path="/find/pw" element={<FindPwPage />} />
       </Routes>
     </div>
   );


### PR DESCRIPTION
### ✨ 작업한 내용
![image](https://user-images.githubusercontent.com/88219703/180691857-98f3d612-1fb2-4b36-91ca-86944f8a7e08.png)
![image](https://user-images.githubusercontent.com/88219703/180691889-213f84fa-86c9-47f3-93eb-cff793b0625b.png)

- 아이디 찾기 페이지와 비밀번호 찾기 페이지를 구분해서 생성
- 아이디 찾기 페이지는 이름, 전화번호 input과 찾기 버튼을 가지는 컴포넌트로 구성
- 비밀번호 찾기 페이지는 아이디, 이름, 전화번호 input과 찾기 버튼을 가지는 컴포넌트로 구성
- 페이지에서 아이디 찾기나 비밀번호 찾기 링크를 누르면 해당 페이지로 이동하도록 navigate을 사용
-  로그인 페이지에서 아이디 찾기나 비밀번호 찾기를 눌러 해당 페이지로 이동하도록 navigate을 사용
- 각 페이지의 input, button, span 및 div에 styled-component 적용
---
### ❗ 리뷰 시 참고사항
 - 아직 찾기 버튼을 누르고 난 뒤의 결과 페이지는 구현이 안 된 상태입니다. 따라서 버튼을 눌러도 아직은 일어나는 일이 없습니다
 - 아직 서버와 통신하는 코드도 구현이 되어 있지 않습니다
---

### 💡 새롭게 알게 된 점

---

### ❓ 고민 중인 부분
 - 찾기 버튼을 눌렀을 때 다음 페이지로 넘어갈 때 submit한 input의 값을 useNavigate()의 parameter로 넣고, 결과 페이지에서 location.state으로 parameter를 가져와 결과 페이지에서 서버와 통신을 할 생각입니다.  
 - 서버와 통신 (id/pw 가져오기 또는 정보 없음 )을 찾기 페이지에서 진행하고 그 결과만을 parameter로 결과 페이지에 전달할 수도 있는데 둘 중 어떤 방법이 더 좋을지 고민중입니다.
---

### 📘 참고 자료 
