### PR TITLE
[1/n - 10] 채팅 페이지 스타일 수정

### DIFF
--- a/src/component/chat/ChatRoom.jsx
+++ b/src/component/chat/ChatRoom.jsx
@@ -12,7 +12,7 @@ const ChatRoom = () => {
         targetNum={5}
         isChief={true}
         usersInfo={[
-          { name: "김OO" },
+          { name: "김나라나라날나라라라리" },
           { name: "최OO" },
           { name: "박OO" },
           { name: "구OO" },

--- a/src/component/chat/ChatRoomHeader.jsx
+++ b/src/component/chat/ChatRoomHeader.jsx
@@ -1,6 +1,9 @@
 import React, { useState } from "react";
 import styled from "styled-components";
 import StateTag from "../common/StateTag";
+import AlarmSubInfoStyle from "../style/AlarmSubInfoStyle";
+import DropDownListStyle from "../style/DropDownListStyle";
+import DropDownWrapperStyle from "../style/DropDownWrapperStyle";
 import ChatStateTag from "./ChatStateTag";
 const Color = {
   YELLOW: "#fa983a",
@@ -27,46 +30,91 @@ const ChatRoomHeader = ({
   };
   return (
     <ChatHeaderWrapper>
-      <div>
-        <H4>{roomName}</H4>
+      <TitleWrapper>
+        <RoomName>{roomName}</RoomName>
         <ChatStateTag state={state} />
 
         {/* 방장 태그 리팩토링 필요 */}
         {isChief && (
           <StateTag bg={Color.NAVY} string={"방장"} color={Color.WHITE} />
         )}
+      </TitleWrapper>
+
+      <SubInfoDiv>
         <UserInfoWrapper>
-          <span onClick={onMemberClick}>
-            {`참여 인원 : ${targetNum}명 `}
-            {isMemberTabOpened ? "🔼" : "🔽"}
-          </span>
+          <UserTabBtn onClick={onMemberClick}>{`👤 ${targetNum}`}</UserTabBtn>
           {isMemberTabOpened && (
             <UserTab>
-              <ul>
-                {usersInfo.map((user, key) => (
-                  <li key={`user_${key}`}>🍕{user.name}</li>
-                ))}
-              </ul>
+              <DropDownWrapperStyle minWidth={150} radius={10}>
+                <ul>
+                  {usersInfo.map((user, key) => (
+                    <DropDownListStyle
+                      key={`user_${key}`}
+                      height={50}
+                      isFirst={key === 0}
+                      isLast={key === usersInfo.length - 1}
+                      radius={10}
+                    >
+                      <UserNameWrapper>
+                        <NameIcon>🍕</NameIcon>
+                        <NameSpan>{user.name}</NameSpan>
+                      </UserNameWrapper>
+                    </DropDownListStyle>
+                  ))}
+                </ul>
+              </DropDownWrapperStyle>
             </UserTab>
           )}
         </UserInfoWrapper>
-      </div>
-      <div>
-        <span>{`💵1인당 배달비 : ${feePerOne}원 `}</span>
-        <span>{`📍${location}`}</span>
-      </div>
+        <AlarmSubInfoStyle>
+          <span>{`💵1인당 배달비 : ${feePerOne}원 `}</span>
+          <span>{`📍${location}`}</span>
+        </AlarmSubInfoStyle>
+      </SubInfoDiv>
     </ChatHeaderWrapper>
   );
 };
 
 export default ChatRoomHeader;
-
+const userBtnHeight = 32;
 const ChatHeaderWrapper = styled.div`
-  background-color: ${Color.ORANGE};
+  background-color: #ffeee6;
+  width: 100%;
+  height: 80px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0px 15px 0 20px;
+`;
+const TitleWrapper = styled.div`
+  display: flex;
+  padding-top: 4px;
+  flex-direction: row;
+  align-items: baseline;
+`;
+const RoomName = styled.div`
+  display: inline-block;
+  font-size: 20px;
+  font-weight: 600;
+  padding-right: 10px;
 `;
 
-const H4 = styled.h4`
-  display: inline-block;
+const SubInfoDiv = styled.div`
+  align-self: flex-end;
+  text-align: right;
+  padding-bottom: 3px;
+`;
+const UserTabBtn = styled.button`
+  height: ${userBtnHeight}px;
+  width: 70px;
+  border-radius: ${userBtnHeight / 2}px;
+  border: 3px solid #f35a3c;
+  background-color: white;
+  font-size: 13px;
+  &:hover {
+    background-color: #f35a3c;
+  }
 `;
 
 const UserTab = styled.div`
@@ -76,5 +124,33 @@ const UserTab = styled.div`
 
 const UserInfoWrapper = styled.div`
   position: relative;
+  line-hieght: 100%;
+  display: inline-block;
+  text-align: right;
+`;
+
+const UserNameWrapper = styled.div`
+  font-size: 15px;
+  height: 100%;
+  text-align: left;
+  padding: 3px 10px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+const NameIcon = styled.span`
+  display: inline-block;
+  font-size: 20px;
+  padding-right: 5px;
+`;
+const NameSpan = styled.span`
   display: inline-block;
 `;
+// const MenuWrappper = styled.div`
+//   position: absolute;
+//   right: 10px;
+//   background-color: white;
+//   z-index: 10;
+//   border-radius: ${10}px;
+//   width: 180px;
+// `;

--- a/src/component/chat/ChatRoomInfoDiv.jsx
+++ b/src/component/chat/ChatRoomInfoDiv.jsx
@@ -72,8 +72,3 @@ const SubInfoSpan = styled.span`
   display: inline-block;
   width: ${({ width }) => width};
 `;
-
-const MemNumSpan = styled.span`
-  display: inline-block;
-  padding-right: 4px;
-`;

--- a/src/component/chat/ChatRoomInfoDiv.jsx
+++ b/src/component/chat/ChatRoomInfoDiv.jsx
@@ -1,6 +1,8 @@
 import React from "react";
 import ChatStateTag from "./ChatStateTag";
 import StateTag from "../common/StateTag";
+import AlarmSubInfoStyle from "../style/AlarmSubInfoStyle";
+import styled from "styled-components";
 
 const Color = {
   YELLOW: "#fa983a",
@@ -21,23 +23,57 @@ const ChatRoomInfoDiv = ({
   location,
 }) => {
   return (
-    <div>
-      <div>
-        <strong>{roomName}</strong>
+    <ChatRoomInfoWrapper>
+      <TitleWrapper>
+        <RoomName>{roomName}</RoomName>
 
         <ChatStateTag state={state} />
 
         {isChief && (
           <StateTag string="방장 " bg={Color.NAVY} color={Color.WHITE} />
         )}
-      </div>
-      <div>
-        <span>👤{targetNum} </span>
-        <span>{` 💵1인당 배달비 : ${feePerOne}원`}</span>
-        <span>{`📍${location}`}</span>
-      </div>
-    </div>
+        {/* <MemNumSpan>👤{targetNum}</MemNumSpan> */}
+      </TitleWrapper>
+      <AlarmSubInfoStyle>
+        {/* <MemNumSpan>👤{targetNum}</MemNumSpan> */}
+        {/* <SubInfoSpan width={"10%"}>👤{targetNum}</SubInfoSpan> */}
+        <SubInfoSpan
+          width={"40%"}
+        >{` 💵1인당 배달비 : ${feePerOne}원`}</SubInfoSpan>
+        <SubInfoSpan width={"40%"}>{`📍${location}`}</SubInfoSpan>
+        <SubInfoSpan width={"20%"}>👤{targetNum}</SubInfoSpan>
+      </AlarmSubInfoStyle>
+    </ChatRoomInfoWrapper>
   );
 };
 
 export default ChatRoomInfoDiv;
+const ChatRoomInfoWrapper = styled.div`
+  width: 100%;
+`;
+
+const TitleWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+`;
+
+const RoomName = styled.div`
+  display: inline-block;
+  font-size: 20px;
+  font-weight: bold;
+  padding: 8px 8px 4px 0;
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+`;
+
+const SubInfoSpan = styled.span`
+  display: inline-block;
+  width: ${({ width }) => width};
+`;
+
+const MemNumSpan = styled.span`
+  display: inline-block;
+  padding-right: 4px;
+`;

--- a/src/component/chat/ChatRoomsInfo.jsx
+++ b/src/component/chat/ChatRoomsInfo.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import styled from "styled-components";
 import ChatRoomInfoDiv from "./ChatRoomInfoDiv";
 
 const ChatRoomsInfo = () => {
@@ -40,7 +41,7 @@ const ChatRoomsInfo = () => {
     <div>
       <ul>
         {chatRoomsData.map((data, key) => (
-          <li key={key}>
+          <ChatRoomInfoLi key={key}>
             <ChatRoomInfoDiv
               roomName={`${data.storeName}-${data.roomId}`}
               state={data.state}
@@ -49,7 +50,7 @@ const ChatRoomsInfo = () => {
               feePerOne={parseInt(data.totalFee / data.targetNum)}
               location={data.location}
             />
-          </li>
+          </ChatRoomInfoLi>
         ))}
       </ul>
     </div>
@@ -57,3 +58,16 @@ const ChatRoomsInfo = () => {
 };
 
 export default ChatRoomsInfo;
+
+const ChatRoomInfoLi = styled.li`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 90px;
+  border-bottom: 0.3px solid #ced6e0;
+  padding: 15px 10px 10px 20px;
+  &:hover {
+    cursor: pointer;
+    background-color: #ecf0f1;
+  }
+`;

--- a/src/component/chat/ChattingInput.jsx
+++ b/src/component/chat/ChattingInput.jsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from "react";
+import styled from "styled-components";
 
 const ChattingInput = ({ isDelivered }) => {
   const [chatText, setChatText] = useState("");
@@ -13,18 +14,66 @@ const ChattingInput = ({ isDelivered }) => {
   }, [isDelivered]);
 
   return (
-    <div>
+    <ChatInputWrapper>
       {isDelivered && (
         <div>
-          <button onClick={onExitBtnClick}>{`🔄️ 채팅방 나가기`}</button>
+          <ExitBtn onClick={onExitBtnClick}>{`🔄️ 채팅방 나가기`}</ExitBtn>
         </div>
       )}
-      <div>
-        <input type="text" onChange={onChange} value={chatText} />
-        <button>보내기</button>
-      </div>
-    </div>
+      <InputNBtnDiv>
+        <Input type="text" onChange={onChange} value={chatText} />
+        <SendBtn disabled={chatText.length === 0}>보내기</SendBtn>
+      </InputNBtnDiv>
+    </ChatInputWrapper>
   );
 };
 
 export default ChattingInput;
+const height = 50;
+const ChatInputWrapper = styled.div`
+  width: 100%;
+  padding: 0 20px;
+`;
+
+const InputNBtnDiv = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+`;
+
+const Input = styled.input`
+  display: inline-block;
+  width: 90%;
+  height: ${height}px;
+  border-radius: ${height / 2}px;
+  border: 0.5px solid #ced6e0;
+  font-size: 18px;
+  padding: 0 30px;
+`;
+
+const ExitBtn = styled.button`
+  background-color: transparent;
+  margin: 10px 0;
+  &:hover {
+    background-color: transparent;
+  }
+`;
+
+const SendBtn = styled.button`
+  height: ${height - 5}px;
+  width: 75px;
+  border-radius: ${(height - 5) / 2}px;
+  font-size: 16px;
+  margin-left: 10px;
+  background-color: #f56649;
+  &:hover {
+    background-color: #f35a3c;
+  }
+  &:disabled {
+    background-color: #bdc3c7;
+    &:hover {
+      background-color: #bdc3c7;
+      cursor: default;
+    }
+  }
+`;

--- a/src/component/common/StateTag.jsx
+++ b/src/component/common/StateTag.jsx
@@ -10,9 +10,16 @@ const StateTag = ({ string, color, bg }) => {
 };
 
 export default StateTag;
-
+const height = 22;
 const TagWrapper = styled.div`
   display: inline-block;
+  margin: 0 2px;
+  padding: 0 8px;
+  height: ${height}px;
+  border-radius: ${height / 2}px;
   background-color: ${({ bg }) => bg};
   color: ${({ color }) => color};
+  font-size: 13px;
+  line-height: ${height}px;
+  text-align: center;
 `;

--- a/src/component/style/DropDownListStyle.jsx
+++ b/src/component/style/DropDownListStyle.jsx
@@ -1,0 +1,18 @@
+import styled from "styled-components";
+
+const DropDownListStyle = styled.li`
+height: ${({ height }) => height}px;
+border-bottom: ${({ isLast }) => (isLast ? "none" : "0.3px solid #ced6e0;")};
+&:hover {
+  cursor: pointer;
+  background-color: #ecf0f1;
+  border-radius: ${({ isFirst, isLast, wrapperRadius }) =>
+    isFirst
+      ? `${wrapperRadius}px ${wrapperRadius}px 0 0`
+      : isLast
+      ? `0 0 ${wrapperRadius}px ${wrapperRadius}px`
+      : "none"};
+
+`;
+
+export default DropDownListStyle;

--- a/src/component/style/DropDownWrapperStyle.jsx
+++ b/src/component/style/DropDownWrapperStyle.jsx
@@ -1,0 +1,12 @@
+import styled from "styled-components";
+
+const DropDownWrapperStyle = styled.div`
+  position: absolute;
+  right: 10px;
+  background-color: white;
+  z-index: 10;
+  border-radius: ${({ radius }) => `${radius}`}px;
+  min-width: ${({ minWidth }) => `${minWidth}px`};
+`;
+
+export default DropDownWrapperStyle;

--- a/src/component/style/GlobalStyles.jsx
+++ b/src/component/style/GlobalStyles.jsx
@@ -24,6 +24,14 @@ button{
     }
     
 }
+input {
+    outline:none;
+    padding: 0;
+    margin:0;
+    &:focus{
+        outline:none;
+    }
+}
 `;
 
 export default GlobalStyles;

--- a/src/pages/chat/ChatPage.jsx
+++ b/src/pages/chat/ChatPage.jsx
@@ -21,10 +21,12 @@ export default ChatPage;
 const ChatPageWrapper = styled.div`
   display: flex;
   flex-direction: row;
+  height: 80vh;
 `;
 
 const SideNavWrapper = styled.div`
   width: 30%;
+  border-right: 1px solid #ced6e0;
 `;
 
 const ChatRoomWrapper = styled.div`


### PR DESCRIPTION
### ✨ 작업한 내용
![image](https://user-images.githubusercontent.com/77582221/180822315-e82f57e3-db1d-41a5-b8fe-6a098282b341.png)
![image](https://user-images.githubusercontent.com/77582221/180822392-32507678-7673-458a-abd9-86326e5029e6.png)

- 채팅방 목록 컴포넌트 스타일 추가 
- 채팅방 헤더 스타일 추가 
- 채팅방 입력창 스타일 추가 
- input 태그 전역 스타일 추가
---
### ❗ 리뷰 시 참고사항
input 태그에 대한 전역 스타일을 GlobalStyles.jsx에 추가하였습니다. 
input 태그의 default style 중 outline, margin,  padding, 그리고 focus 시 outline을 제거하였습니다. 

---

### 💡 새롭게 알게 된 점

---

### ❓ 고민 중인 부분
채팅방 내부 말풍선 기능 및 스타일과 전반적인 그림자 효과는 추후에 구현할 예정입니다. 

---

### 📘 참고 자료 

---
Closes #33 