### PR TITLE
[1/n - 16] 히스토리 페이지 구현 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "1-n-web-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@fortawesome/fontawesome-svg-core": "^6.1.1",
+        "@fortawesome/fontawesome-svg-core": "^6.1.2",
         "@fortawesome/free-regular-svg-icons": "^6.1.1",
         "@fortawesome/free-solid-svg-icons": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.2.0",
@@ -2194,13 +2194,22 @@
       }
     },
     "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.1.tgz",
-      "integrity": "sha512-NCg0w2YIp81f4V6cMGD9iomfsIj7GWrqmsa0ZsPh59G7PKiGN1KymZNxmF00ssuAlo/VZmpK6xazsGOwzKYUMg==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.2.tgz",
+      "integrity": "sha512-853G/Htp0BOdXnPoeCPTjFrVwyrJHpe8MhjB/DYE9XjwhnNDfuBCd3aKc2YUYbEfHEcBws4UAA0kA9dymZKGjA==",
       "hasInstallScript": true,
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.1.1"
+        "@fortawesome/fontawesome-common-types": "6.1.2"
       },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core/node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.2.tgz",
+      "integrity": "sha512-wBaAPGz1Awxg05e0PBRkDRuTsy4B3dpBm+zreTTyd9TH4uUM27cAL4xWyWR0rLJCrRwzVsQ4hF3FvM6rqydKPA==",
+      "hasInstallScript": true,
       "engines": {
         "node": ">=6"
       }
@@ -18313,11 +18322,18 @@
       "integrity": "sha512-wVn5WJPirFTnzN6tR95abCx+ocH+3IFLXAgyavnf9hUmN0CfWoDjPT/BAWsUVwSlYYVBeCLJxaqi7ZGe4uSjBA=="
     },
     "@fortawesome/fontawesome-svg-core": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.1.tgz",
-      "integrity": "sha512-NCg0w2YIp81f4V6cMGD9iomfsIj7GWrqmsa0ZsPh59G7PKiGN1KymZNxmF00ssuAlo/VZmpK6xazsGOwzKYUMg==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.2.tgz",
+      "integrity": "sha512-853G/Htp0BOdXnPoeCPTjFrVwyrJHpe8MhjB/DYE9XjwhnNDfuBCd3aKc2YUYbEfHEcBws4UAA0kA9dymZKGjA==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "6.1.1"
+        "@fortawesome/fontawesome-common-types": "6.1.2"
+      },
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.2.tgz",
+          "integrity": "sha512-wBaAPGz1Awxg05e0PBRkDRuTsy4B3dpBm+zreTTyd9TH4uUM27cAL4xWyWR0rLJCrRwzVsQ4hF3FvM6rqydKPA=="
+        }
       }
     },
     "@fortawesome/free-regular-svg-icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
+        "recoil": "^0.7.4",
         "styled-components": "^5.3.5",
         "web-vitals": "^2.1.4"
       }
@@ -8462,6 +8463,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+    },
     "node_modules/handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -14156,6 +14162,25 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recoil": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.4.tgz",
+      "integrity": "sha512-sCXvQGMfSprkNU4ZRkJV4B0qFQSURJMgsICqY1952WRlg66NMwYqi6n67vhnhn0qw4zHU1gHXJuMvRDaiRNFZw==",
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/recursive-readdir": {
@@ -22906,6 +22931,11 @@
         "duplexer": "^0.1.2"
       }
     },
+    "hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+    },
     "handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -26864,6 +26894,14 @@
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "recoil": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.4.tgz",
+      "integrity": "sha512-sCXvQGMfSprkNU4ZRkJV4B0qFQSURJMgsICqY1952WRlg66NMwYqi6n67vhnhn0qw4zHU1gHXJuMvRDaiRNFZw==",
+      "requires": {
+        "hamt_plus": "1.0.2"
       }
     },
     "recursive-readdir": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^6.1.1",
+    "@fortawesome/fontawesome-svg-core": "^6.1.2",
     "@fortawesome/free-regular-svg-icons": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@fortawesome/react-fontawesome": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
+    "recoil": "^0.7.4",
     "styled-components": "^5.3.5",
     "web-vitals": "^2.1.4"
   },

--- a/src/component/Header/MyPageMenu.jsx
+++ b/src/component/Header/MyPageMenu.jsx
@@ -1,19 +1,26 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 const menuName = ["참여 현황", "개인정보 변경하기"];
 const MyPageMenu = () => {
+  const navigate = useNavigate();
+  const onHistoryClick = () => {
+    navigate("/history");
+  };
+
+  const onMyPageClick = () => {
+    navigate("/user");
+  };
   return (
     <MenuWrappper>
       <ul>
-        {menuName.map((m, key) => (
-          <MenuLi
-            key={`menuName_${key}`}
-            isFirst={key === 0}
-            isLast={key === menuName.length - 1}
-          >
-            {m}
-          </MenuLi>
-        ))}
+        <MenuLi isFirst={true} isLast={false} onClick={onHistoryClick}>
+          {menuName[0]}
+        </MenuLi>
+
+        <MenuLi isFirst={false} isLast={true} onClick={onMyPageClick}>
+          {menuName[1]}
+        </MenuLi>
       </ul>
     </MenuWrappper>
   );

--- a/src/component/common/UserStateTag.jsx
+++ b/src/component/common/UserStateTag.jsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useState } from "react";
+import StateTag from "./StateTag";
+
+const Color = {
+  YELLOW: "#fa983a",
+  RED_PINK: "#eb4d4b",
+  NAVY: "#130f40",
+  WHITE: "white",
+  GREEN: "#44bd32",
+  DARK_YELLOW: "#f7b731",
+  DARK_GREEN: "#16a085",
+  DARK_RED: "#c0392b",
+};
+
+const State = {
+  ORDER_WAITING: 0,
+  ORDER_COMPLETE: 1,
+  DELIVERY_COMPLETE: 2,
+  REQ_WAITING: 3,
+  ACCEPTED: 4,
+  DENIED: 5,
+  CHIEF: 6,
+};
+
+Object.freeze(Color);
+Object.freeze(State);
+
+const UserStateTag = ({ state }) => {
+  const [stateTagData, setStateTagData] = useState({
+    color: "",
+    bg: "",
+    string: "",
+  });
+
+  useEffect(() => {
+    switch (state) {
+      case State.ORDER_WAITING:
+        setStateTagData({
+          string: "주문 대기",
+          color: Color.WHITE,
+          bg: Color.RED_PINK,
+        });
+        break;
+      case 1:
+        setStateTagData({
+          string: "주문 완료",
+          color: Color.WHITE,
+          bg: Color.YELLOW,
+        });
+        break;
+      case 2:
+        setStateTagData({
+          string: "배달 완료",
+          color: Color.WHITE,
+          bg: Color.GREEN,
+        });
+        break;
+
+      case State.REQ_WAITING:
+        setStateTagData({
+          string: "대기 중",
+          color: Color.WHITE,
+          bg: Color.DARK_YELLOW,
+        });
+        break;
+      case State.ACCEPTED:
+        setStateTagData({
+          string: "수락",
+          color: Color.WHITE,
+          bg: Color.DARK_GREEN,
+        });
+        break;
+      case State.DENIED:
+        setStateTagData({
+          string: "거절",
+          color: Color.WHITE,
+          bg: Color.DARK_RED,
+        });
+        break;
+      case State.CHIEF:
+        setStateTagData({
+          string: "방장",
+          color: Color.WHITE,
+          bg: Color.NAVY,
+        });
+        break;
+      default:
+        break;
+    }
+  }, [state]);
+
+  return (
+    <StateTag
+      string={stateTagData.string}
+      bg={stateTagData.bg}
+      color={stateTagData.color}
+    />
+  );
+};
+
+export default UserStateTag;

--- a/src/component/history/HistoryDetailInfoTab.jsx
+++ b/src/component/history/HistoryDetailInfoTab.jsx
@@ -10,9 +10,10 @@ const HistoryDetailInfoTab = () => {
     totalMems: 3,
     targetNum: 5,
   });
+
   return (
     <div>
-      <table border={true}>
+      <table>
         <tr>
           <td>🍕 방 이름</td>
           <td>{`${historyInfo.roomName}-${historyInfo.roomId}`}</td>

--- a/src/component/history/HistoryDetailInfoTab.jsx
+++ b/src/component/history/HistoryDetailInfoTab.jsx
@@ -1,0 +1,45 @@
+import React, { useState } from "react";
+
+const HistoryDetailInfoTab = () => {
+  const [historyInfo, setHistoryInfo] = useState({
+    roomName: "원스테이크",
+    roomId: "455",
+    location: "신공학관 정문",
+    feePerOne: 1500,
+    totalFee: 14500,
+    totalMems: 3,
+    targetNum: 5,
+  });
+  return (
+    <div>
+      <table border={true}>
+        <tr>
+          <td>🍕 방 이름</td>
+          <td>{`${historyInfo.roomName}-${historyInfo.roomId}`}</td>
+        </tr>
+        <tr>
+          <td>📍 위치</td>
+          <td>{historyInfo.location}</td>
+        </tr>
+        <tr>
+          <td>💵 1인당 배달비</td>
+          <td>{historyInfo.feePerOne.toLocaleString()}</td>
+        </tr>
+        <tr>
+          <td>💵 총 금액</td>
+          <td>{historyInfo.totalFee.toLocaleString()}</td>
+        </tr>
+        <tr>
+          <td>👤 현재 인원</td>
+          <td>{historyInfo.totalMems}명</td>
+        </tr>
+        <tr>
+          <td>👤 목표 인원</td>
+          <td>{historyInfo.targetNum}명</td>
+        </tr>
+      </table>
+    </div>
+  );
+};
+
+export default HistoryDetailInfoTab;

--- a/src/component/history/HistoryListContainer.jsx
+++ b/src/component/history/HistoryListContainer.jsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useState } from "react";
+import HistoryListHeader from "./HistoryListHeader";
+
+const HistoryListContainer = () => {
+  const [history, setHistory] = useState([
+    {
+      roomName: "새로이",
+      id: 574,
+      totalMems: 3,
+      targetNum: 5,
+      state: 4,
+      isChief: true,
+      feePerOne: 1500,
+      totalFee: 12400,
+      location: "신공학관 정문",
+    },
+    {
+      roomName: "시홍쓰",
+      id: 55,
+      totalMems: 2,
+      targetNum: 3,
+      state: 4,
+      isChief: false,
+      feePerOne: 1500,
+      totalFee: 12400,
+      location: "동생대 정문",
+    },
+    {
+      roomName: "새로이",
+      id: 324,
+      totalMems: 3,
+      targetNum: 5,
+      state: 5,
+      isChief: false,
+      feePerOne: 1500,
+      totalFee: 12400,
+      location: "신공학관 정문",
+    },
+    {
+      roomName: "부리또피아",
+      id: 22,
+      totalMems: 4,
+      targetNum: 4,
+      state: 1,
+      isChief: true,
+      feePerOne: 1500,
+      totalFee: 12400,
+      location: "신공학관 정문",
+    },
+    {
+      roomName: "불떡",
+      id: 12,
+      totalMems: 4,
+      targetNum: 4,
+      state: 1,
+      isChief: true,
+      feePerOne: 1500,
+      totalFee: 12400,
+      location: "신공학관 정문",
+    },
+    {
+      roomName: "포크포크",
+      id: 87,
+      totalMems: 3,
+      targetNum: 3,
+      state: 0,
+      isChief: false,
+      feePerOne: 1500,
+      totalFee: 12400,
+      location: "신공학관 정문",
+    },
+  ]);
+
+  useEffect(() => {
+    // 데이터 받아오기
+  }, []);
+  return (
+    <div>
+      <ul>
+        {history.map((h, key) => (
+          <li key={`history_${key}`}>
+            <HistoryListHeader
+              roomName={`${h.roomName}-${h.id}`}
+              totalMems={h.totalMems}
+              targetNum={h.targetNum}
+              state={h.state}
+              isChief={h.isChief}
+              feePerOne={h.feePerOne}
+              totalFee={h.totalFee}
+              location={h.location}
+            />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default HistoryListContainer;

--- a/src/component/history/HistoryListContainer.jsx
+++ b/src/component/history/HistoryListContainer.jsx
@@ -81,6 +81,7 @@ const HistoryListContainer = () => {
           <li key={`history_${key}`}>
             <HistoryListHeader
               roomName={`${h.roomName}-${h.id}`}
+              roomId={h.id}
               totalMems={h.totalMems}
               targetNum={h.targetNum}
               state={h.state}

--- a/src/component/history/HistoryListHeader.jsx
+++ b/src/component/history/HistoryListHeader.jsx
@@ -3,6 +3,8 @@ import AlarmSubInfoStyle from "../style/AlarmSubInfoStyle";
 import styled from "styled-components";
 import UserStateTag from "../common/UserStateTag";
 import { useNavigate } from "react-router-dom";
+import { useSetRecoilState } from "recoil";
+import historyDataAtom from "../../recoil/historyData/atom";
 
 const HistoryListHeader = ({
   roomName,
@@ -16,12 +18,21 @@ const HistoryListHeader = ({
   location,
 }) => {
   const navigate = useNavigate();
+
+  const setHistoryDataAtom = useSetRecoilState(historyDataAtom);
+
   const onChatClick = () => {
     navigate("/chat");
     // param으로든 뭐든 채팅방 아이디 보내기
   };
+
+  const onClick = (e) => {
+    setHistoryDataAtom((cur) => ({ ...cur, isPopUpOpen: true }));
+    // id 로 검색 후 set Recoil에 넣어주기
+  };
+
   return (
-    <HistoryHeaderWrapper>
+    <HistoryHeaderWrapper onClick={onClick}>
       <div>
         <TitleWrapper>
           <div>

--- a/src/component/history/HistoryListHeader.jsx
+++ b/src/component/history/HistoryListHeader.jsx
@@ -2,9 +2,11 @@ import React from "react";
 import AlarmSubInfoStyle from "../style/AlarmSubInfoStyle";
 import styled from "styled-components";
 import UserStateTag from "../common/UserStateTag";
+import { useNavigate } from "react-router-dom";
 
 const HistoryListHeader = ({
   roomName,
+  roomId,
   totalMems,
   targetNum,
   state,
@@ -13,53 +15,61 @@ const HistoryListHeader = ({
   totalFee,
   location,
 }) => {
+  const navigate = useNavigate();
+  const onChatClick = () => {
+    navigate("/chat");
+    // param으로든 뭐든 채팅방 아이디 보내기
+  };
   return (
-    <ChatRoomInfoWrapper>
-      <TitleWrapper>
-        <div>
-          <RoomName>{roomName}</RoomName>
-
-          {(state < 3 || !isChief) && <UserStateTag state={state} />}
-
-          {isChief && <UserStateTag state={6} />}
+    <HistoryHeaderWrapper>
+      <div>
+        <TitleWrapper>
           <div>
-            <button>ℹ️</button>
-            <button>🍕</button>
-            {isChief && (
-              <button>
-                {state < 3 ? (
-                  <span>👤{targetNum}</span>
-                ) : (
-                  <span>👤{`${totalMems}/${targetNum}`}</span>
-                )}
-              </button>
-            )}
-            {state < 3 && <button>💬</button>}
-          </div>
-        </div>
-        <div>
-          {(state === 3 || state === 4) && (
-            <button>{isChief ? "방 삭제하기" : "취소하기"}</button>
-          )}
-        </div>
-      </TitleWrapper>
-      <AlarmSubInfoStyle>
-        <SubInfoSpan
-          width={"30%"}
-        >{` 🍔1인당 배달비 : ${feePerOne.toLocaleString()}원`}</SubInfoSpan>
-        <SubInfoSpan
-          width={"30%"}
-        >{` 💵전체 금액 : ${totalFee.toLocaleString()}원`}</SubInfoSpan>
+            <RoomName>{roomName}</RoomName>
 
-        <SubInfoSpan width={"40%"}>{`📍${location}`}</SubInfoSpan>
-      </AlarmSubInfoStyle>
-    </ChatRoomInfoWrapper>
+            {(state < 3 || !isChief) && <UserStateTag state={state} />}
+
+            {isChief && <UserStateTag state={6} />}
+            <div>
+              <button>ℹ️</button>
+              <button>🍕</button>
+              {isChief && (
+                <button>
+                  {state < 3 ? (
+                    <span>👤{targetNum}</span>
+                  ) : (
+                    <span>👤{`${totalMems}/${targetNum}`}</span>
+                  )}
+                </button>
+              )}
+              {state < 3 && <button onClick={onChatClick}>💬</button>}
+            </div>
+          </div>
+          <div>
+            {(state === 3 || state === 4) && (
+              <button>{isChief ? "방 삭제하기" : "취소하기"}</button>
+            )}
+          </div>
+        </TitleWrapper>
+        <AlarmSubInfoStyle>
+          <SubInfoSpan
+            width={"30%"}
+          >{` 🍔1인당 배달비 : ${feePerOne.toLocaleString()}원`}</SubInfoSpan>
+          <SubInfoSpan
+            width={"30%"}
+          >{` 💵전체 금액 : ${totalFee.toLocaleString()}원`}</SubInfoSpan>
+
+          <SubInfoSpan width={"40%"}>{`📍${location}`}</SubInfoSpan>
+        </AlarmSubInfoStyle>
+      </div>
+      <div></div>
+    </HistoryHeaderWrapper>
   );
 };
 
 export default HistoryListHeader;
 
-const ChatRoomInfoWrapper = styled.div`
+const HistoryHeaderWrapper = styled.div`
   width: 100%;
 `;
 

--- a/src/component/history/HistoryListHeader.jsx
+++ b/src/component/history/HistoryListHeader.jsx
@@ -1,0 +1,85 @@
+import React from "react";
+import AlarmSubInfoStyle from "../style/AlarmSubInfoStyle";
+import styled from "styled-components";
+import UserStateTag from "../common/UserStateTag";
+
+const HistoryListHeader = ({
+  roomName,
+  totalMems,
+  targetNum,
+  state,
+  isChief,
+  feePerOne,
+  totalFee,
+  location,
+}) => {
+  return (
+    <ChatRoomInfoWrapper>
+      <TitleWrapper>
+        <div>
+          <RoomName>{roomName}</RoomName>
+
+          {(state < 3 || !isChief) && <UserStateTag state={state} />}
+
+          {isChief && <UserStateTag state={6} />}
+          <div>
+            <button>ℹ️</button>
+            <button>🍕</button>
+            {isChief && (
+              <button>
+                {state < 3 ? (
+                  <span>👤{targetNum}</span>
+                ) : (
+                  <span>👤{`${totalMems}/${targetNum}`}</span>
+                )}
+              </button>
+            )}
+            {state < 3 && <button>💬</button>}
+          </div>
+        </div>
+        <div>
+          {(state === 3 || state === 4) && (
+            <button>{isChief ? "방 삭제하기" : "취소하기"}</button>
+          )}
+        </div>
+      </TitleWrapper>
+      <AlarmSubInfoStyle>
+        <SubInfoSpan
+          width={"30%"}
+        >{` 🍔1인당 배달비 : ${feePerOne.toLocaleString()}원`}</SubInfoSpan>
+        <SubInfoSpan
+          width={"30%"}
+        >{` 💵전체 금액 : ${totalFee.toLocaleString()}원`}</SubInfoSpan>
+
+        <SubInfoSpan width={"40%"}>{`📍${location}`}</SubInfoSpan>
+      </AlarmSubInfoStyle>
+    </ChatRoomInfoWrapper>
+  );
+};
+
+export default HistoryListHeader;
+
+const ChatRoomInfoWrapper = styled.div`
+  width: 100%;
+`;
+
+const TitleWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+`;
+
+const RoomName = styled.div`
+  display: inline-block;
+  font-size: 20px;
+  font-weight: bold;
+  padding: 8px 8px 4px 0;
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+`;
+
+const SubInfoSpan = styled.span`
+  display: inline-block;
+  width: ${({ width }) => width};
+`;

--- a/src/component/history/HistoryOrderList.jsx
+++ b/src/component/history/HistoryOrderList.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 
-const HistoryOrderList = () => {
+const HistoryOrderList = ({ orderData, isPartySection = false }) => {
   const [orderList, setOrderList] = useState([
     { foodName: "참치 김밥", price: 3500 },
     { foodName: "우동", price: 6000 },
@@ -19,11 +19,15 @@ const HistoryOrderList = () => {
     setTotalFee(totalFoodPrice + deliveryFee);
   }, [orderList, deliveryFee]);
 
+  useEffect(() => {
+    if (isPartySection) setOrderList(orderData);
+  }, [orderData, isPartySection]);
+
   return (
     <div>
       <ul>
         {orderList.map((o, key) => (
-          <li>
+          <li key={`order_${key}`}>
             <strong>{o.foodName}</strong>
             <span>{o.price.toLocaleString()}원</span>
           </li>

--- a/src/component/history/HistoryOrderList.jsx
+++ b/src/component/history/HistoryOrderList.jsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from "react";
+
+const HistoryOrderList = () => {
+  const [orderList, setOrderList] = useState([
+    { foodName: "참치 김밥", price: 3500 },
+    { foodName: "우동", price: 6000 },
+    { foodName: "돈까스", price: 9000 },
+    { foodName: "주먹밥", price: 3000 },
+  ]);
+  const [deliveryFee, setDeliveryFee] = useState(1500);
+  const [totalFee, setTotalFee] = useState(0);
+
+  useEffect(() => {
+    const totalFoodPrice = orderList.reduce(
+      (prevSum, curValue) => prevSum + curValue.price,
+      0
+    );
+
+    setTotalFee(totalFoodPrice + deliveryFee);
+  }, [orderList, deliveryFee]);
+
+  return (
+    <div>
+      <ul>
+        {orderList.map((o, key) => (
+          <li>
+            <strong>{o.foodName}</strong>
+            <span>{o.price.toLocaleString()}원</span>
+          </li>
+        ))}
+      </ul>
+      <div>
+        <strong>배달비</strong>
+        <span>{deliveryFee.toLocaleString()}원</span>
+      </div>
+      <hr />
+      <div>
+        <strong>총 가격</strong>
+        <span>{totalFee.toLocaleString()}원</span>
+      </div>
+    </div>
+  );
+};
+
+export default HistoryOrderList;

--- a/src/component/history/HistoryPartyList.jsx
+++ b/src/component/history/HistoryPartyList.jsx
@@ -1,9 +1,11 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
+import styled from "styled-components";
+import HistoryOrderList from "./HistoryOrderList";
 
 const HistoryPartyList = () => {
   const [users, setUsers] = useState([
     {
-      username: "닉닉넴",
+      userName: "닉닉넴",
       orderList: [
         { foodName: "참치 김밥", price: 3500 },
         { foodName: "우동", price: 6000 },
@@ -11,39 +13,68 @@ const HistoryPartyList = () => {
       ],
     },
     {
-      username: "닉네힘",
+      userName: "닉네힘",
       orderList: [
         { foodName: "안심돈까스", price: 10000 },
         { foodName: "냉모밀", price: 7000 },
       ],
     },
     {
-      username: "닉네네",
+      userName: "닉네네",
       orderList: [{ foodName: "야채 김밥", price: 3000 }],
     },
   ]);
+  const [didSelect, setDidSelect] = useState(false);
+  const [targetUser, setTargetUser] = useState({
+    userName: null,
+    orderList: [],
+  });
 
   const onMouseEnter = (e) => {
-    const targetName = e.target.dataset.name;
-    console.log(targetName);
+    if (didSelect) return;
+
+    const targetData = findTargetData(e.target.dataset.name);
+    setTargetUser(targetData);
   };
 
   const onMouseLeave = () => {
-    console.log("ousts");
+    if (didSelect) return;
+
+    setTargetUser((curData) => ({ ...curData, userName: null }));
   };
+
+  const findTargetData = (userName) =>
+    users.find((u) => u.userName === userName);
+
+  const onClick = (e) => {
+    setDidSelect((curState) => !curState);
+    setTargetUser(findTargetData(e.target.dataset.name));
+  };
+
   return (
     <div>
       <ul>
         {users.map((u, key) => (
-          <li
+          <Li
             key={`user_${key}`}
-            data-name={u.username}
+            data-name={u.userName}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
+            onClick={onClick}
           >
-            <span data-name={u.username}>🍕</span>
-            <strong data-name={u.username}>{u.username}</strong>
-          </li>
+            <span data-name={u.userName}>🍕</span>
+            <strong data-name={u.userName}>{u.userName}</strong>
+
+            {/* mouse hover 또는 클릭하면 등장하는 order 정보 */}
+            {targetUser.userName === u.userName && (
+              <OrderListWrapper key={`target_${key}`}>
+                <HistoryOrderList
+                  isPartySection={true}
+                  orderData={targetUser.orderList}
+                />
+              </OrderListWrapper>
+            )}
+          </Li>
         ))}
       </ul>
     </div>
@@ -51,3 +82,14 @@ const HistoryPartyList = () => {
 };
 
 export default HistoryPartyList;
+
+const Li = styled.li`
+  position: relative;
+`;
+
+const OrderListWrapper = styled.div`
+  position: absolute;
+  background-color: white;
+  top: 0px;
+  right: 0px;
+`;

--- a/src/component/history/HistoryPartyList.jsx
+++ b/src/component/history/HistoryPartyList.jsx
@@ -1,0 +1,53 @@
+import React, { useState } from "react";
+
+const HistoryPartyList = () => {
+  const [users, setUsers] = useState([
+    {
+      username: "닉닉넴",
+      orderList: [
+        { foodName: "참치 김밥", price: 3500 },
+        { foodName: "우동", price: 6000 },
+        { foodName: "돈까스", price: 9000 },
+      ],
+    },
+    {
+      username: "닉네힘",
+      orderList: [
+        { foodName: "안심돈까스", price: 10000 },
+        { foodName: "냉모밀", price: 7000 },
+      ],
+    },
+    {
+      username: "닉네네",
+      orderList: [{ foodName: "야채 김밥", price: 3000 }],
+    },
+  ]);
+
+  const onMouseEnter = (e) => {
+    const targetName = e.target.dataset.name;
+    console.log(targetName);
+  };
+
+  const onMouseLeave = () => {
+    console.log("ousts");
+  };
+  return (
+    <div>
+      <ul>
+        {users.map((u, key) => (
+          <li
+            key={`user_${key}`}
+            data-name={u.username}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
+          >
+            <span data-name={u.username}>🍕</span>
+            <strong data-name={u.username}>{u.username}</strong>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default HistoryPartyList;

--- a/src/component/history/HistoryPopup.jsx
+++ b/src/component/history/HistoryPopup.jsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { useSetRecoilState } from "recoil";
+import styled from "styled-components";
+import historyDataAtom from "../../recoil/historyData/atom";
+import HistoryListHeader from "./HistoryListHeader";
+import HistoryTab from "./HistoryTab";
+
+const HistoryPopup = () => {
+  const setHistoryDataAtom = useSetRecoilState(historyDataAtom);
+  const onDelClick = () => {
+    // recoil stae 변경 하여 popup 사라지도록
+    setHistoryDataAtom((cur) => ({ ...cur, isPopUpOpen: false }));
+  };
+  return (
+    <PopUpBackground>
+      <PopUpWrapper>
+        <DelBtnWrapper>
+          <DelBtn onClick={onDelClick}>❌</DelBtn>
+        </DelBtnWrapper>
+        <HistoryListHeader
+          roomName={"recoil"}
+          roomId={"recoil"}
+          totalMems={3}
+          targetNum={5}
+          state={4}
+          isChief={true}
+          feePerOne={1500}
+          totalFee={14500}
+          location={"신공학관 정문"}
+        />
+        {/* 선택된 히스토리 내역을 어떻게 전달할 건지 */}
+        <HistoryTab />
+      </PopUpWrapper>
+    </PopUpBackground>
+  );
+};
+
+export default HistoryPopup;
+
+const PopUpWrapper = styled.div`
+  width: 700px;
+  height: 500px;
+  background-color: white;
+  border-radius: 5px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow: auto;
+  position: relative;
+`;
+
+const PopUpBackground = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  z-index: 1;
+`;
+
+const DelBtnWrapper = styled.div`
+  text-align: right;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  width: 100%;
+  position: absolute;
+`;
+
+const DelBtn = styled.span`
+  display: inline-block;
+`;

--- a/src/component/history/HistoryTab.jsx
+++ b/src/component/history/HistoryTab.jsx
@@ -1,0 +1,43 @@
+import React, { useState } from "react";
+import HistoryDetailInfoTab from "./HistoryDetailInfoTab";
+import HistoryOrderList from "./HistoryOrderList";
+import HistoryPartyList from "./HistoryPartyList";
+const tabName = ["세부 정보", "주문 내역", "참여 인원"];
+Object.freeze(tabName);
+
+const HistoryTab = () => {
+  const [curIdx, setCurIdx] = useState(0);
+  const onTabClick = (e) => {
+    setCurIdx(parseInt(e.target.dataset.idx));
+  };
+  return (
+    <div>
+      <div>
+        {tabName.map((tName, key) => (
+          <button key={`historyTab_${key}`} data-idx={key} onClick={onTabClick}>
+            {tName}
+          </button>
+        ))}
+      </div>
+      <div>
+        {curIdx === 0 && (
+          <div>
+            <HistoryDetailInfoTab />
+          </div>
+        )}
+        {curIdx === 1 && (
+          <div>
+            <HistoryOrderList />
+          </div>
+        )}
+        {curIdx === 2 && (
+          <div>
+            <HistoryPartyList />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default HistoryTab;

--- a/src/component/history/RequestStateTag.jsx
+++ b/src/component/history/RequestStateTag.jsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from "react";
+import StateTag from "../common/StateTag";
+
+const key = {
+  WAITING: 0,
+  ACCEPTED: 1,
+  DENIED: 2,
+};
+
+Object.freeze(key);
+
+const RequestStateTag = ({ state }) => {
+  const [data, setData] = useState({ string: "", color: "", bg: "" });
+  useEffect(() => {
+    switch (state) {
+      case key.WAITING:
+        setData({
+          string: "대기 중",
+          color: "white",
+          bg: "#f7b731",
+        });
+        break;
+      case key.ACCEPTED:
+        setData({
+          string: "수락",
+          color: "white",
+          bg: "#16a085",
+        });
+        break;
+      case key.DENIED:
+        setData({
+          string: "거절",
+          color: "white",
+          bg: "#c0392b",
+        });
+        break;
+      default:
+        setData({
+          string: "대기 중",
+          color: "white",
+          bg: "#f7b731",
+        });
+        break;
+    }
+  }, [state]);
+
+  return (
+    <StateTag string={data.string} color={data.color} bg={data.bg}></StateTag>
+  );
+};
+
+export default RequestStateTag;

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,15 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { RecoilRoot } from "recoil";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
 const root = ReactDOM.createRoot(document.getElementById("root"));
+
 root.render(
   <React.StrictMode>
-    <App />
+    <RecoilRoot>
+      <App />
+    </RecoilRoot>
   </React.StrictMode>
 );
 

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import HistoryListContainer from "../component/history/HistoryListContainer";
+
+const HistoryPage = () => {
+  return (
+    <div>
+      <HistoryListContainer />
+    </div>
+  );
+};
+
+export default HistoryPage;

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -1,10 +1,20 @@
-import React from "react";
+import React, { useEffect } from "react";
+import { useRecoilValue, useRecoilState } from "recoil";
 import HistoryListContainer from "../component/history/HistoryListContainer";
+import HistoryPopup from "../component/history/HistoryPopup";
+import historyDataAtom from "../recoil/historyData/atom";
 
 const HistoryPage = () => {
+  const [historyData, setHistoryData] = useRecoilState(historyDataAtom);
+  useEffect(
+    () => setHistoryData((cur) => ({ ...cur, isPopUpOpen: false })),
+    []
+  );
   return (
     <div>
       <HistoryListContainer />
+
+      {historyData.isPopUpOpen && <HistoryPopup />}
     </div>
   );
 };

--- a/src/recoil/historyData/atom.js
+++ b/src/recoil/historyData/atom.js
@@ -1,0 +1,11 @@
+import { atom } from "recoil";
+
+const historyDataAtom = atom({
+  key: "historyDataAtom",
+  default: {
+    isPopUpOpen: false,
+    // popUp에 띄울 다른 정보들
+  },
+});
+
+export default historyDataAtom;

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -12,6 +12,7 @@ import UserInfo from "../pages/userInfo";
 
 import FindIdPage from "../pages/findIdPage";
 import FindPwPage from "../pages/findPwPage";
+import HistoryPage from "../pages/HistoryPage";
 const Router = () => {
   return (
     <div>
@@ -29,6 +30,8 @@ const Router = () => {
 
         <Route path="/find/id" element={<FindIdPage />} />
         <Route path="/find/pw" element={<FindPwPage />} />
+
+        <Route path="/history" element={<HistoryPage />} />
       </Routes>
     </div>
   );


### PR DESCRIPTION
### ✨ 작업한 내용
- 히스토리 리스트 헤더 생성
- 히스토리 팝업창 구현 ( recoil 사용) 
- 히스토리 팝업 탭 컴포넌트 구현
 - 히스토리 팝업 정보 탭 구현
 - 히스토리 팝업 음식 탭 구현
 - 히스토리 팝업 참여인원 탭 구현
 - 히스토리 페이지 구현
---
### ❗ 리뷰 시 참고사항
 recoil의 디렉토리 구조와 파일명은 [링크](https://wes-rast.medium.com/recoil-project-structure-best-practices-79e74a475caa) 를 참고하였습니다. 

클릭한 리스트에 따른 팝업 내용 변화는 서버 연결시 구현할 예정입니다. 
또한, 히스토리 페이지의 스타일도 변경할 예정입니다. 


---

### 💡 새롭게 알게 된 점

---

### ❓ 고민 중인 부분
리스트에서 `ℹ️`, `🍕` 또는 `👤`버튼을 누르면 팝업창에서 해당 탭이 먼저 보이도록 구현되길 원합니다. 
recoil atom의 state를 변경하여 이를 구현하려고 했으나 잘 작동되지 않아 해결책을 찾는 중입니다. 


---

### 📘 참고 자료 
- [https://wes-rast.medium.com/recoil-project-structure-best-practices-79e74a475caa](https://wes-rast.medium.com/recoil-project-structure-best-practices-79e74a475caa) 

Closes #43  
