### PR TITLE
[1/n - 35] 채팅 목록 클릭 시 채팅방 헤더에 정보 안 나타나는 문제 해결  

### DIFF
--- a/src/component/chat/ChatRoom.jsx
+++ b/src/component/chat/ChatRoom.jsx
@@ -27,7 +27,7 @@ const ChatRoom = () => {
 
   useEffect(() => {
     getChatRoomInfo(roomId);
-  }, []);
+  }, [roomId]);
 
   const getChatRoomInfo = async (roomId) => {
     if (roomId === undefined) return;


### PR DESCRIPTION
### ✨ 작업한 내용
- url  param 변경 될 때 채팅방 내용 다시 렌더링 하도록 구현 

---
### ❗ 리뷰 시 참고사항


---

### 💡 새롭게 알게 된 점

---

### ❓ 고민 중인 부분

---

### 📘 참고 자료 


Closes #78 
