### PR TITLE
[1/n - 69] menuEntry 이미지 출력 안됨 bug fix

### DIFF
--- a/src/component/createRoom/menuEntry.jsx
+++ b/src/component/createRoom/menuEntry.jsx
@@ -5,7 +5,7 @@ const MenuEntry = ({ menu }) => {
   const { imageUrl, menuId, name, price } = menu;
   return (
     <Menu className="box" key={menuId}>
-      <Img src={imageUrl} alt="default" />
+      <Img src={`http://localhost:8080/image/menu/${imageUrl}`} alt="default" />
       <InfoWrapper>
         <span>{name}</span>
         <span>{price}원</span>


### PR DESCRIPTION
### ✨ 작업한 내용
- createRoom의 menuEntry 컴포넌트에서 서버로부터 가져온 이미지가 정상적으로 출력되지 않는 버그를 해결했습니다.
---
### ❗ 리뷰 시 참고사항
 

---

### 💡 새롭게 알게 된 점

---

### ❓ 고민 중인 부분

---

### 📘 참고 자료 
- [링크](링크) 형식
Closes #154 