### PR TITLE
[1/n - 72] 채팅 화면에서 다른 화면으로 이동 후 채팅방 재입장시 채팅이 입력되지 않는 문제

### DIFF
--- a/src/component/chat/ChatRoom.jsx
+++ b/src/component/chat/ChatRoom.jsx
@@ -42,7 +42,6 @@ const ChatRoom = () => {
         }
       );
       const data = response.data;
-      console.log(data);
       setChatData({
         roomName: `${data.storeName}-${data.postId}`,
         state: data.postState,
@@ -52,7 +51,6 @@ const ChatRoom = () => {
         location: data.spotId,
         isChief: data.owner,
       });
-      console.log(response.data.owner);
     } catch (err) {
       console.log(err);
     }
@@ -91,11 +89,11 @@ const ChatRoom = () => {
 export default ChatRoom;
 
 const ChatMainWrapper = styled.div`
-  display:flex;
-  flex-direction:column;
-  width:100%;
-  height:100%;
-`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+`;
 
 const DefaultDivWrapper = styled.div`
   display: flex;

--- a/src/component/chat/Chatting.jsx
+++ b/src/component/chat/Chatting.jsx
@@ -11,11 +11,13 @@ const Chatting = ({ roomId, state }) => {
   const [messages, setMessages] = useState([]);
   const [message, setMessage] = useState("");
 
-  const client = useRef(new Client());
+  const client = useRef();
   const subscription = useRef();
   const scrollRef = useRef();
 
   useEffect(() => {
+    client.current = new Client();
+
     setMessages([]);
     getPastMessages();
     getSocketToken();

--- a/src/component/chat/Chatting.jsx
+++ b/src/component/chat/Chatting.jsx
@@ -6,55 +6,23 @@ import ChatBubbleWrapper from "./ChatBubbleWrapper";
 import styled from "styled-components";
 import ChattingInput from "./ChattingInput";
 
-// let client = new Client();
-
 const Chatting = ({ roomId, state }) => {
   const [nickname, setNickname] = useState("");
   const [messages, setMessages] = useState([]);
   const [message, setMessage] = useState("");
 
-  const testRef = useRef({ roomId: parseInt(roomId) }); // 초깃값을 지정하면 최초 렌더링시 의 값으로 고정되는 듯
-  const testRef2 = useRef(roomId);
-  const testRef3 = useRef();
   const client = useRef(new Client());
   const subscription = useRef();
   const scrollRef = useRef();
 
-  // test
-  // useEffect(() => {
-  //   // console.log(testRef);
-  //   console.log(messages);
-  // }, [messages]);
-
   useEffect(() => {
-    // if (client.current.state === ActivationState.ACTIVE) {
-    // }
-    // client.current = new Client();
-    // console.log("새로렌더링");
-    console.log(client.current);
-    // testRef3.current = 100;
-    // console.log(testRef3);
-    // testRef3.current = 200;
-    // console.log(testRef3);
-
-    // console.log(` messages: ${messages}`);
     setMessages([]);
     getPastMessages();
     getSocketToken();
-    // console.log(roomId);
-    // console.log(testRef.current);
-    // console.log(testRef2.current);
-    // testRef2.current = 1000;
-    // console.log(testRef2.current);
 
-    testRef.current.roomId = roomId * 100;
-    console.log(testRef.current);
     return () => {
-      // console.log("이건 ...안되니?");
       subscription.current.unsubscribe();
       client.current.deactivate();
-      // client.current.state = ActivationState.INACTIVE;
-      // console.log(client.current.connected);
     };
   }, [roomId]);
 
@@ -88,8 +56,6 @@ const Chatting = ({ roomId, state }) => {
         }
       );
 
-      // console.log(response.data);
-
       setMessages(
         response.data
           .filter((message) => message.type !== "ENTER")
@@ -110,7 +76,6 @@ const Chatting = ({ roomId, state }) => {
     try {
       client.current.brokerURL = `ws://localhost:8080/ws/chat?token=${socketToken}`;
 
-      console.log(client.current.connected);
       // 소켓 연결 후 실행되는 콜백 함수
       client.current.onConnect = (frame) => {
         // 채팅방 입장
@@ -121,8 +86,6 @@ const Chatting = ({ roomId, state }) => {
           `/sub/chat/room/${roomId}`,
           (data) => {
             const newMessage = JSON.parse(data.body);
-            console.log("구독 안된듯?");
-            // 왜 구독이 안될까
             if (newMessage.type === "ENTER") return;
             setMessages((cur) => [
               ...cur,
@@ -137,7 +100,6 @@ const Chatting = ({ roomId, state }) => {
         );
       };
 
-      // console.log(client.current.onConnect);
       // 연결 실패할 경우 실행되는 콜백 함수
       client.current.onStompError = (frame) => {
         console.log("Broker reported error: " + frame.headers["message"]);
@@ -146,7 +108,6 @@ const Chatting = ({ roomId, state }) => {
 
       // 소켓 활성화
       client.current.activate();
-      console.log("isConnected: ", client.current.connected);
     } catch (err) {
       console.log(err);
     }
@@ -192,7 +153,6 @@ const Chatting = ({ roomId, state }) => {
 
   // 메세지 생성 시 마다 아래로 스크롤 하는 함수
   useEffect(() => {
-    // console.log(scrollRef);
     if (!scrollRef.current) return;
     scrollRef.current.scrollIntoView({
       behavior: "smooth",
@@ -219,8 +179,6 @@ const Chatting = ({ roomId, state }) => {
             />
           </div>
         ))}
-        {/* <button onClick={enterChatRoom}>참가하깃</button>
-      <button onClick={onSampleClick}>채팅 보내깃</button> */}
       </BubbleWrapper>
       <ChattingInput
         isDelivered={state && state === "DELIVERY_COMPLETE"}

--- a/src/component/chat/Chatting.jsx
+++ b/src/component/chat/Chatting.jsx
@@ -170,9 +170,8 @@ const Chatting = ({ roomId, state }) => {
     <ChatSection>
       <BubbleWrapper>
         {messages.map((m, key) => (
-          <div ref={scrollRef}>
+          <div ref={scrollRef} key={`chat_bubble_${key}`}>
             <ChatBubbleWrapper
-              key={`chat_bubble_${key}`}
               nickname={m.nickname}
               icon=""
               content={m.content}

--- a/src/component/chat/Chatting.jsx
+++ b/src/component/chat/Chatting.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef } from "react";
 import axios from "axios";
-import { Client, ActivationState } from "@stomp/stompjs";
+import { Client } from "@stomp/stompjs";
 
 import ChatBubbleWrapper from "./ChatBubbleWrapper";
 import styled from "styled-components";
@@ -13,23 +13,48 @@ const Chatting = ({ roomId, state }) => {
   const [messages, setMessages] = useState([]);
   const [message, setMessage] = useState("");
 
+  const testRef = useRef({ roomId: parseInt(roomId) }); // 초깃값을 지정하면 최초 렌더링시 의 값으로 고정되는 듯
+  const testRef2 = useRef(roomId);
+  const testRef3 = useRef();
   const client = useRef(new Client());
-  const subscription = useRef(null);
+  const subscription = useRef();
   const scrollRef = useRef();
 
+  // test
+  // useEffect(() => {
+  //   // console.log(testRef);
+  //   console.log(messages);
+  // }, [messages]);
+
   useEffect(() => {
-    if (client.current.state === ActivationState.ACTIVE) {
-    }
+    // if (client.current.state === ActivationState.ACTIVE) {
+    // }
+    // client.current = new Client();
+    // console.log("새로렌더링");
+    console.log(client.current);
+    // testRef3.current = 100;
+    // console.log(testRef3);
+    // testRef3.current = 200;
+    // console.log(testRef3);
 
     // console.log(` messages: ${messages}`);
     setMessages([]);
     getPastMessages();
     getSocketToken();
-    console.log(roomId);
+    // console.log(roomId);
+    // console.log(testRef.current);
+    // console.log(testRef2.current);
+    // testRef2.current = 1000;
+    // console.log(testRef2.current);
+
+    testRef.current.roomId = roomId * 100;
+    console.log(testRef.current);
     return () => {
-      console.log("이건 ...안되니?");
+      // console.log("이건 ...안되니?");
       subscription.current.unsubscribe();
-      client.current.state = ActivationState.INACTIVE;
+      client.current.deactivate();
+      // client.current.state = ActivationState.INACTIVE;
+      // console.log(client.current.connected);
     };
   }, [roomId]);
 
@@ -63,7 +88,7 @@ const Chatting = ({ roomId, state }) => {
         }
       );
 
-      console.log(response.data);
+      // console.log(response.data);
 
       setMessages(
         response.data
@@ -85,6 +110,7 @@ const Chatting = ({ roomId, state }) => {
     try {
       client.current.brokerURL = `ws://localhost:8080/ws/chat?token=${socketToken}`;
 
+      console.log(client.current.connected);
       // 소켓 연결 후 실행되는 콜백 함수
       client.current.onConnect = (frame) => {
         // 채팅방 입장
@@ -95,7 +121,8 @@ const Chatting = ({ roomId, state }) => {
           `/sub/chat/room/${roomId}`,
           (data) => {
             const newMessage = JSON.parse(data.body);
-            console.log(newMessage);
+            console.log("구독 안된듯?");
+            // 왜 구독이 안될까
             if (newMessage.type === "ENTER") return;
             setMessages((cur) => [
               ...cur,
@@ -110,6 +137,7 @@ const Chatting = ({ roomId, state }) => {
         );
       };
 
+      // console.log(client.current.onConnect);
       // 연결 실패할 경우 실행되는 콜백 함수
       client.current.onStompError = (frame) => {
         console.log("Broker reported error: " + frame.headers["message"]);
@@ -118,6 +146,7 @@ const Chatting = ({ roomId, state }) => {
 
       // 소켓 활성화
       client.current.activate();
+      console.log("isConnected: ", client.current.connected);
     } catch (err) {
       console.log(err);
     }
@@ -143,6 +172,7 @@ const Chatting = ({ roomId, state }) => {
       alert("Broker disconnected, can't send message.");
       return false;
     }
+
     if (msg.length > 0) {
       const payLoad = {
         content: msg,
@@ -162,7 +192,7 @@ const Chatting = ({ roomId, state }) => {
 
   // 메세지 생성 시 마다 아래로 스크롤 하는 함수
   useEffect(() => {
-    console.log(scrollRef);
+    // console.log(scrollRef);
     if (!scrollRef.current) return;
     scrollRef.current.scrollIntoView({
       behavior: "smooth",

--- a/src/component/chat/Chatting.jsx
+++ b/src/component/chat/Chatting.jsx
@@ -130,7 +130,7 @@ const Chatting = ({ roomId, state }) => {
       body: JSON.stringify({
         content: "",
         type: "ENTER",
-        postId: 1,
+        postId: roomId,
         nickname: nickname,
       }),
     });
@@ -147,7 +147,7 @@ const Chatting = ({ roomId, state }) => {
       const payLoad = {
         content: msg,
         type: "TALK",
-        postId: 1,
+        postId: roomId,
         nickname: nickname,
       };
 

--- a/src/component/chat/ChattingInput.jsx
+++ b/src/component/chat/ChattingInput.jsx
@@ -20,11 +20,9 @@ const ChattingInput = ({ isDelivered, setMessage }) => {
       const doesReallyExit = window.confirm("정말 나가시겠습니까?");
       if (!doesReallyExit) return;
 
-      const response = await axios.delete(
-        `http://localhost:8080/post/${roomId}`,
-        { headers: { Authorization: localStorage.getItem("Authorization") } }
-      );
-      console.log(response);
+      await axios.delete(`http://localhost:8080/post/${roomId}`, {
+        headers: { Authorization: localStorage.getItem("Authorization") },
+      });
 
       setIsChatDataChanged(true);
       navigate("/chat");
@@ -33,33 +31,16 @@ const ChattingInput = ({ isDelivered, setMessage }) => {
     }
   }, [isDelivered]);
 
-  // const exitRoom = async () => {
-  //   try {
-  //     const response = await axios.delete(
-  //       `http://localhost:8080/post/${roomId}`,
-  //       { headers: { Authorization: localStorage.getItem("Authorization") } }
-  //     );
-  //     console.log(response);
-  //   } catch (err) {
-  //     console.log(err);
-  //   }
-  // };
   const onSend = () => {
     setMessage(chatText);
     setChatText("");
   };
 
   const onKeyUp = (e) => {
-    console.log(e);
     if (e.code === "Enter") {
-      // setChatText((cur)=> cur.substring(0, cur.length))
       onSend();
     }
   };
-
-  useEffect(() => {
-    console.log(chatText);
-  }, [chatText]);
 
   return (
     <ChatInputWrapper>


### PR DESCRIPTION
### ✨ 작업한 내용
-  다른 페이지 갔다와도 채팅 기능 수행되도록 수정 
    - unmount 될 때 unsubscribe, disconnect하는 구문 추가
- enter, publish 할 채팅방 id가 1로 고정되어있던 부분 수정 
-  다른 채팅방 클릭 시 메세지 구독 안되는 문제 해결
    - disconnect 코드 오류 수정
- roomId 바뀔 때마다 client 객체 새로 생성되도록 수정 
- 채팅방 말풍선에 key값 설정 
---
### ❗ 리뷰 시 참고사항
 

---

### 💡 새롭게 알게 된 점
stomp js 6.1.2 버전에서, client의 connect를 완전히 disconnect (자동 재연결 안함) 하기 위해서는 `deactivate` 함수를 사용해야 합니다. 
`deactivate` 함수는 비동기 함수로, deactivate가 완전히 끝난 후에 client 객체를 다시 activate 하거나, 아예 client 객체를 새로 만들어야 아래와 같은 에러를 막을 수 있습니다. 
<br/>
![화면 캡처 2022-09-18 020659](https://user-images.githubusercontent.com/77582221/190868445-7eb5be12-7902-457f-bd82-760d2035019e.png)

<br/>

---

### ❓ 고민 중인 부분

---

### 📘 참고 자료 
- [stomp js 6.1.2 document](https://stomp-js.github.io/api-docs/latest/classes/Client.html#deactivate)
- [WebSocket 채팅 클라이언트 구현기](https://iborymagic.tistory.com/93)
- [useRef](https://ko.reactjs.org/docs/hooks-reference.html#useref)

Resolves #159 